### PR TITLE
fix URL typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In mathematical optimization, the Ackley function is a non-convex function used 
 
 Credits : 
 
-1.   [Wiki](https://https://en.wikipedia.org/wiki/Ackley_function)
-2.   <a href="https://https://books.google.lk/books?id=sx_VBwAAQBAJ&printsec=frontcover&redir_esc=y#v=snippet&q=%22Ackley%20function%22&f=false">Ackley, D. H. (1987) "A connectionist machine for genetic hillclimbing"</a>
+1.   [Wiki](https://en.wikipedia.org/wiki/Ackley_function)
+2.   <a href="https://books.google.lk/books?id=sx_VBwAAQBAJ&printsec=frontcover&redir_esc=y#v=snippet&q=%22Ackley%20function%22&f=false">Ackley, D. H. (1987) "A connectionist machine for genetic hillclimbing"</a>
 3. camo.githubusercontent.com
 


### PR DESCRIPTION
remove double `https://` prefix generating errors on click

![image](https://github.com/adhishagc/Ackley-Function/assets/1699252/23fc4926-f9c3-4719-a33e-51566f0fce9b)
